### PR TITLE
docs: add startup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,23 @@ cd phdata
 uv sync
 ```
 
+
 ### Training the Model
 
-```bash
-# Run the complete training pipeline
-uv run kfp-pipeline run-local
+Before training the model, you must run the following commands to set up the database and migrate data:
+
+```fish
+uv run alembic upgrade head
+uv run python scripts/migrate_data.py migrate-all
 ```
+
+Then, to train the model, run:
+
+```fish
+uv run property-value-estimator-pipeline run-docker/run-local
+```
+
+The output of the training pipeline will be saved in the `pipeline_outputs/` directory.
 
 ### Making Predictions
 


### PR DESCRIPTION
This pull request updates the `README.md` documentation for the model training process, making it clearer and more accurate. The main changes reorganize the instructions, add necessary setup steps, and specify output details.

**Documentation improvements:**

* Added prerequisite steps for database setup and data migration before training, including commands for running Alembic migrations and the data migration script.
* Updated the training command to use `property-value-estimator-pipeline run-docker/run-local` instead of the previous command, improving clarity and accuracy.
* Clarified that the training pipeline output will be saved in the `pipeline_outputs/` directory.